### PR TITLE
fix self peer not updated when joining lobby

### DIFF
--- a/doc_classes/AuthoritativeLobbyClient.xml
+++ b/doc_classes/AuthoritativeLobbyClient.xml
@@ -44,7 +44,7 @@
 			</description>
 		</method>
 		<method name="connect_to_lobby">
-			<return type="bool" />
+			<return type="LobbyResponse" />
 			<description>
 				Connect to a Blazium Lobby Server using the [member game_id] and [member server_url].
 				Generates [signal connected_to_lobby] signal if successful.
@@ -82,7 +82,7 @@
 			</description>
 		</method>
 		<method name="disconnect_from_lobby">
-			<return type="void" />
+			<return type="LobbyResponse" />
 			<description>
 				Disconnect from the lobby server.
 				Generates [signal disconnected_from_lobby] signal.

--- a/doc_classes/LobbyClient.xml
+++ b/doc_classes/LobbyClient.xml
@@ -72,7 +72,7 @@
 			</description>
 		</method>
 		<method name="connect_to_lobby">
-			<return type="bool" />
+			<return type="LobbyResponse" />
 			<description>
 				Connect to a Blazium Lobby Server using the [member game_id] and [member server_url].
 				Generates [signal connected_to_lobby] signal if successful.
@@ -141,7 +141,7 @@
 			</description>
 		</method>
 		<method name="disconnect_from_lobby">
-			<return type="void" />
+			<return type="LobbyResponse" />
 			<description>
 				Disconnect from the lobby server.
 				Generates [signal disconnected_from_lobby] signal.

--- a/lobby/authoritative_lobby_client.cpp
+++ b/lobby/authoritative_lobby_client.cpp
@@ -123,10 +123,18 @@ Ref<LobbyPeer> AuthoritativeLobbyClient::get_peer() { return peer; }
 TypedArray<LobbyPeer> AuthoritativeLobbyClient::get_peers() { return peers; }
 Dictionary AuthoritativeLobbyClient::get_peer_data() { return peer_data; }
 
-bool AuthoritativeLobbyClient::connect_to_lobby() {
-	if (connected) {
-		return true;
+Ref<LobbyResponse> AuthoritativeLobbyClient::connect_to_lobby() {
+	Ref<LobbyResponse> response;
+	response.instantiate();
+	// if there is another command connect, finish that with error
+	if (_commands.has("connect")) {
+		Ref<LobbyResponse> old_response = _commands.get("connect", Ref<LobbyResponse>());
+		Ref<LobbyResponse::LobbyResult> result;
+		result.instantiate();
+		result->set_error("Trying to connect twice");
+		old_response->emit_signal("finished", result);
 	}
+	_commands["connect"] = response;
 	String lobby_url = get_server_url();
 	String url = lobby_url;
 	PackedStringArray protocols;
@@ -137,29 +145,36 @@ bool AuthoritativeLobbyClient::connect_to_lobby() {
 	}
 	_socket->set_supported_protocols(protocols);
 	Error err = _socket->connect_to_url(url);
-	if (err != OK) {
-		set_process_internal(false);
-		emit_signal("log_updated", "error", "Unable to connect to lobby server at: " + url);
-		connected = false;
-		return false;
-	}
 	set_process_internal(true);
+	if (err != OK) {
+		emit_signal("log_updated", "error", "Unable to connect to lobby server at: " + url);
+		return response;
+	}
 	emit_signal("log_updated", "connect_to_lobby", "Connecting to: " + url);
-	return true;
+	return response;
 }
 
-void AuthoritativeLobbyClient::disconnect_from_lobby() {
-	if (connected) {
-		_socket->close(1000, "Normal Closure");
-		connected = false;
-		peer->set_data(Dictionary());
-		peers.clear();
-		lobby->set_dict(Dictionary());
-		peer_data = Dictionary();
-		set_process_internal(false);
-		emit_signal("disconnected_from_lobby", _socket->get_close_reason());
-		emit_signal("log_updated", "disconnect_from_lobby", "Disconnected from: " + get_server_url());
+Ref<LobbyResponse> AuthoritativeLobbyClient::disconnect_from_lobby() {
+	Ref<LobbyResponse> response;
+	response.instantiate();
+	// if there is another disconnect connect, finish that with error
+	if (_commands.has("disconnect")) {
+		Ref<LobbyResponse> old_response = _commands.get("disconnect", Ref<LobbyResponse>());
+		Ref<LobbyResponse::LobbyResult> result;
+		result.instantiate();
+		result->set_error("Trying to disconnect twice");
+		old_response->emit_signal("finished", result);
 	}
+	_commands["disconnect"] = response;
+	set_process_internal(true);
+	_socket->close(1000, "Normal Closure");
+	connected = false;
+	peer_data = Dictionary();
+	peer->set_data(Dictionary());
+	peers.clear();
+	lobby->set_dict(Dictionary());
+	emit_signal("log_updated", "disconnect_from_lobby", "Disconnecting from: " + get_server_url());
+	return response;
 }
 
 String AuthoritativeLobbyClient::_increment_counter() {
@@ -433,6 +448,12 @@ void AuthoritativeLobbyClient::_notification(int p_what) {
 
 			WebSocketPeer::State state = _socket->get_ready_state();
 			if (state == WebSocketPeer::STATE_OPEN) {
+				if (_commands.has("connect")) {
+					Ref<LobbyResponse> response = _commands["connect"];
+					Ref<LobbyResponse::LobbyResult> result;
+					response->emit_signal("finished", result);
+					_commands.erase("connect");
+				}
 				if (!connected) {
 					connected = true;
 					emit_signal("log_updated", "connect_to_lobby", "Connected to: " + server_url);
@@ -448,6 +469,12 @@ void AuthoritativeLobbyClient::_notification(int p_what) {
 					_receive_data(JSON::parse_string(packet_string));
 				}
 			} else if (state == WebSocketPeer::STATE_CLOSED) {
+				if (_commands.has("disconnect")) {
+					Ref<LobbyResponse> response = _commands["disconnect"];
+					Ref<LobbyResponse::LobbyResult> result;
+					response->emit_signal("finished", result);
+					_commands.erase("disconnect");
+				}
 				_clear_lobby();
 				emit_signal("log_updated", "error", _socket->get_close_reason());
 				emit_signal("disconnected_from_lobby", _socket->get_close_reason());

--- a/lobby/authoritative_lobby_client.cpp
+++ b/lobby/authoritative_lobby_client.cpp
@@ -481,6 +481,10 @@ void AuthoritativeLobbyClient::_update_peers(Dictionary p_data_dict, TypedArray<
 		if (peer_dict.has("private_data")) {
 			peer_data = peer_dict.get("private_data", Dictionary());
 		}
+		// update self peer
+		if (peer_info->get_id() == peer->get_id()) {
+			peer->set_dict(peer_info->get_dict());
+		}
 		p_peers.push_back(peer_info);
 	}
 }

--- a/lobby/authoritative_lobby_client.h
+++ b/lobby/authoritative_lobby_client.h
@@ -83,8 +83,8 @@ public:
 	Ref<LobbyPeer> get_peer();
 	TypedArray<LobbyPeer> get_peers();
 
-	bool connect_to_lobby();
-	void disconnect_from_lobby();
+	Ref<LobbyResponse> connect_to_lobby();
+	Ref<LobbyResponse> disconnect_from_lobby();
 	Ref<ViewLobbyResponse> create_lobby(const String &p_name, const Dictionary &p_tags, int p_max_players, const String &p_password);
 	Ref<ViewLobbyResponse> join_lobby(const String &p_lobby_id, const String &p_password);
 	Ref<LobbyResponse> leave_lobby();

--- a/lobby/lobby_client.cpp
+++ b/lobby/lobby_client.cpp
@@ -136,10 +136,18 @@ void LobbyClient::set_peer(const Ref<LobbyPeer> &p_peer) { this->peer = p_peer; 
 Ref<LobbyPeer> LobbyClient::get_peer() { return peer; }
 TypedArray<LobbyPeer> LobbyClient::get_peers() { return peers; }
 
-bool LobbyClient::connect_to_lobby() {
-	if (connected) {
-		return true;
+Ref<LobbyResponse> LobbyClient::connect_to_lobby() {
+	Ref<LobbyResponse> response;
+	response.instantiate();
+	// if there is another command connect, finish that with error
+	if (_commands.has("connect")) {
+		Ref<LobbyResponse> old_response = _commands.get("connect", Ref<LobbyResponse>());
+		Ref<LobbyResponse::LobbyResult> result;
+		result.instantiate();
+		result->set_error("Trying to connect twice");
+		old_response->emit_signal("finished", result);
 	}
+	_commands["connect"] = response;
 	String lobby_url = get_server_url();
 	String url = lobby_url;
 	PackedStringArray protocols;
@@ -150,30 +158,37 @@ bool LobbyClient::connect_to_lobby() {
 	}
 	_socket->set_supported_protocols(protocols);
 	Error err = _socket->connect_to_url(url);
-	if (err != OK) {
-		set_process_internal(false);
-		emit_signal("log_updated", "error", "Unable to connect to lobby server at: " + url);
-		connected = false;
-		return false;
-	}
 	set_process_internal(true);
+	if (err != OK) {
+		emit_signal("log_updated", "error", "Unable to connect to lobby server at: " + url);
+		return response;
+	}
 	emit_signal("log_updated", "connect_to_lobby", "Connecting to: " + url);
-	return true;
+	return response;
 }
 
-void LobbyClient::disconnect_from_lobby() {
-	if (connected) {
-		_socket->close(1000, "Normal Closure");
-		connected = false;
-		host_data = Dictionary();
-		peer_data = Dictionary();
-		peer->set_data(Dictionary());
-		peers.clear();
-		lobby->set_dict(Dictionary());
-		set_process_internal(false);
-		emit_signal("disconnected_from_lobby", _socket->get_close_reason());
-		emit_signal("log_updated", "disconnect_from_lobby", "Disconnected from: " + get_server_url());
+Ref<LobbyResponse> LobbyClient::disconnect_from_lobby() {
+	Ref<LobbyResponse> response;
+	response.instantiate();
+	// if there is another disconnect connect, finish that with error
+	if (_commands.has("disconnect")) {
+		Ref<LobbyResponse> old_response = _commands.get("disconnect", Ref<LobbyResponse>());
+		Ref<LobbyResponse::LobbyResult> result;
+		result.instantiate();
+		result->set_error("Trying to disconnect twice");
+		old_response->emit_signal("finished", result);
 	}
+	_commands["disconnect"] = response;
+	set_process_internal(true);
+	_socket->close(1000, "Normal Closure");
+	connected = false;
+	host_data = Dictionary();
+	peer_data = Dictionary();
+	peer->set_data(Dictionary());
+	peers.clear();
+	lobby->set_dict(Dictionary());
+	emit_signal("log_updated", "disconnect_from_lobby", "Disconnecting from: " + get_server_url());
+	return response;
 }
 
 String LobbyClient::_increment_counter() {
@@ -596,6 +611,12 @@ void LobbyClient::_notification(int p_what) {
 
 			WebSocketPeer::State state = _socket->get_ready_state();
 			if (state == WebSocketPeer::STATE_OPEN) {
+				if (_commands.has("connect")) {
+					Ref<LobbyResponse> response = _commands["connect"];
+					Ref<LobbyResponse::LobbyResult> result;
+					response->emit_signal("finished", result);
+					_commands.erase("connect");
+				}
 				if (!connected) {
 					connected = true;
 					emit_signal("log_updated", "connect_to_lobby", "Connected to: " + server_url);
@@ -611,6 +632,12 @@ void LobbyClient::_notification(int p_what) {
 					_receive_data(JSON::parse_string(packet_string));
 				}
 			} else if (state == WebSocketPeer::STATE_CLOSED) {
+				if (_commands.has("disconnect")) {
+					Ref<LobbyResponse> response = _commands["disconnect"];
+					Ref<LobbyResponse::LobbyResult> result;
+					response->emit_signal("finished", result);
+					_commands.erase("disconnect");
+				}
 				_clear_lobby();
 				emit_signal("log_updated", "error", _socket->get_close_reason());
 				emit_signal("disconnected_from_lobby", _socket->get_close_reason());

--- a/lobby/lobby_client.cpp
+++ b/lobby/lobby_client.cpp
@@ -644,6 +644,10 @@ void LobbyClient::_update_peers(Dictionary p_data_dict, TypedArray<LobbyPeer> &p
 		if (peer_dict.has("private_data")) {
 			peer_data = peer_dict.get("private_data", Dictionary());
 		}
+		// update self peer
+		if (peer_info->get_id() == peer->get_id()) {
+			peer->set_dict(peer_info->get_dict());
+		}
 		p_peers.push_back(peer_info);
 	}
 }

--- a/lobby/lobby_client.h
+++ b/lobby/lobby_client.h
@@ -90,8 +90,8 @@ public:
 	Ref<LobbyPeer> get_peer();
 	TypedArray<LobbyPeer> get_peers();
 
-	bool connect_to_lobby();
-	void disconnect_from_lobby();
+	Ref<LobbyResponse> connect_to_lobby();
+	Ref<LobbyResponse> disconnect_from_lobby();
 	Ref<ViewLobbyResponse> create_lobby(const String &p_name, const Dictionary &p_tags, int p_max_players, const String &p_password);
 	Ref<ViewLobbyResponse> join_lobby(const String &p_lobby_id, const String &p_password);
 	Ref<LobbyResponse> leave_lobby();


### PR DESCRIPTION
After joining a lobby, there might be some info that changed since last time that the peer might not have.