### PR TITLE
Fix lobby events

### DIFF
--- a/lobby/lobby_client.cpp
+++ b/lobby/lobby_client.cpp
@@ -782,13 +782,6 @@ void LobbyClient::_notification(int p_what) {
 					connected = true;
 					emit_signal("log_updated", "connect_to_server", "Connected to: " + server_url);
 				}
-				if (_commands.has("connect")) {
-					Ref<LobbyResponse> response = _commands["connect"];
-					Ref<LobbyResponse::LobbyResult> result;
-					result.instantiate();
-					response->call_deferred("emit_signal", "finished", result);
-					_commands.erase("connect");
-				}
 				while (_socket->get_available_packet_count() > 0) {
 					Vector<uint8_t> packet_buffer;
 					Error err = _socket->get_packet_buffer(packet_buffer);
@@ -919,6 +912,13 @@ void LobbyClient::_receive_data(const Dictionary &p_dict) {
 		peer->set_dict(peer_dict);
 		lobby->set_id(peer_dict.get("lobby_id", ""));
 		reconnection_token = peer_dict.get("reconnection_token", "");
+		if (_commands.has("connect")) {
+			Ref<LobbyResponse> response = _commands["connect"];
+			Ref<LobbyResponse::LobbyResult> result;
+			result.instantiate();
+			response->call_deferred("emit_signal", "finished", result);
+			_commands.erase("connect");
+		}
 		emit_signal("connected_to_server", peer, reconnection_token);
 	} else if (command == "lobby_created") {
 		lobbies.clear();

--- a/lobby/lobby_client.cpp
+++ b/lobby/lobby_client.cpp
@@ -219,7 +219,7 @@ Ref<LobbyResponse> LobbyClient::disconnect_from_server() {
 }
 
 String LobbyClient::_increment_counter() {
-	return String::num(_counter++);
+	return String::num_int64(_counter++);
 }
 
 Ref<ViewLobbyResponse> LobbyClient::quick_join(const String &p_name, const Dictionary &p_tags, int p_max_players) {

--- a/lobby/scripted_lobby_client.cpp
+++ b/lobby/scripted_lobby_client.cpp
@@ -577,13 +577,6 @@ void ScriptedLobbyClient::_notification(int p_what) {
 					connected = true;
 					emit_signal("log_updated", "connect_to_server", "Connected to: " + server_url);
 				}
-				if (_commands.has("connect")) {
-					Ref<LobbyResponse> response = _commands["connect"];
-					Ref<LobbyResponse::LobbyResult> result;
-					result.instantiate();
-					response->call_deferred("emit_signal", "finished", result);
-					_commands.erase("connect");
-				}
 				while (_socket->get_available_packet_count() > 0) {
 					Vector<uint8_t> packet_buffer;
 					Error err = _socket->get_packet_buffer(packet_buffer);
@@ -700,6 +693,13 @@ void ScriptedLobbyClient::_receive_data(const Dictionary &p_dict) {
 		peer->set_dict(peer_dict);
 		lobby->set_id(peer_dict.get("lobby_id", ""));
 		reconnection_token = peer_dict.get("reconnection_token", "");
+		if (_commands.has("connect")) {
+			Ref<LobbyResponse> response = _commands["connect"];
+			Ref<LobbyResponse::LobbyResult> result;
+			result.instantiate();
+			response->call_deferred("emit_signal", "finished", result);
+			_commands.erase("connect");
+		}
 		emit_signal("connected_to_server", peer, reconnection_token);
 	} else if (command == "lobby_created") {
 		lobbies.clear();

--- a/lobby/scripted_lobby_client.cpp
+++ b/lobby/scripted_lobby_client.cpp
@@ -205,7 +205,7 @@ Ref<LobbyResponse> ScriptedLobbyClient::disconnect_from_server() {
 }
 
 String ScriptedLobbyClient::_increment_counter() {
-	return String::num(_counter++);
+	return String::num_int64(_counter++);
 }
 
 Ref<ViewLobbyResponse> ScriptedLobbyClient::quick_join(const String &p_name, const Dictionary &p_tags, int p_max_players) {


### PR DESCRIPTION
Make connect finish happen after data is written (eg. peer id). Use also num64 to get int instead of double for command id.