### PR TITLE
add lobby hosted callback. Called after lobby host changes

### DIFF
--- a/doc_classes/LobbyClient.xml
+++ b/doc_classes/LobbyClient.xml
@@ -377,6 +377,12 @@
 				Signal generated after a lobby is created.
 			</description>
 		</signal>
+		<signal name="lobby_hosted">
+			<param index="0" name="host" type="LobbyPeer" />
+			<description>
+				Signal generated after a lobby host is changed. If there is no host, a peer without id will be sent.
+			</description>
+		</signal>
 		<signal name="lobby_joined">
 			<param index="0" name="lobby" type="LobbyInfo" />
 			<param index="1" name="peers" type="LobbyPeer[]" />

--- a/doc_classes/ScriptedLobbyClient.xml
+++ b/doc_classes/ScriptedLobbyClient.xml
@@ -299,6 +299,12 @@
 				Signal generated after a lobby is created.
 			</description>
 		</signal>
+		<signal name="lobby_hosted">
+			<param index="0" name="host" type="LobbyPeer" />
+			<description>
+				Signal generated after a lobby host is changed. If there is no host, a peer without id will be sent.
+			</description>
+		</signal>
 		<signal name="lobby_joined">
 			<param index="0" name="lobby" type="LobbyInfo" />
 			<param index="1" name="peers" type="LobbyPeer[]" />

--- a/lobby/lobby_client.cpp
+++ b/lobby/lobby_client.cpp
@@ -126,6 +126,7 @@ void LobbyClient::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("lobby_joined", PropertyInfo(Variant::OBJECT, "lobby", PROPERTY_HINT_RESOURCE_TYPE, "LobbyInfo"), PropertyInfo(Variant::ARRAY, "peers", PROPERTY_HINT_ARRAY_TYPE, "LobbyPeer")));
 	ADD_SIGNAL(MethodInfo("lobby_left", PropertyInfo(Variant::BOOL, "kicked")));
 	ADD_SIGNAL(MethodInfo("lobby_sealed", PropertyInfo(Variant::BOOL, "sealed")));
+	ADD_SIGNAL(MethodInfo("lobby_hosted", PropertyInfo(Variant::OBJECT, "host", PROPERTY_HINT_RESOURCE_TYPE, "LobbyPeer")));
 	ADD_SIGNAL(MethodInfo("lobby_tagged", PropertyInfo(Variant::DICTIONARY, "tags")));
 	ADD_SIGNAL(MethodInfo("lobby_passworded", PropertyInfo(Variant::BOOL, "password_protected")));
 	ADD_SIGNAL(MethodInfo("lobby_resized", PropertyInfo(Variant::INT, "max_players")));
@@ -1035,6 +1036,19 @@ void LobbyClient::_receive_data(const Dictionary &p_dict) {
 	} else if (command == "lobby_unsealed") {
 		lobby->set_sealed(false);
 		emit_signal("lobby_sealed", false);
+	} else if (command == "lobby_hosted") {
+		Ref<LobbyPeer> new_host = Ref<LobbyPeer>(memnew(LobbyPeer));
+		String new_host_id = data_dict.get("host_id", String());
+		// find the new host in the peers array
+		for (int i = 0; i < peers.size(); ++i) {
+			Ref<LobbyPeer> peer_info = peers[i];
+			if (peer_info->get_id() == new_host_id) {
+				new_host->set_dict(peer_info->get_dict(), false);
+				break;
+			}
+		}
+		lobby->set_host(new_host_id);
+		emit_signal("lobby_hosted", new_host);
 	} else if (command == "lobby_tags") {
 		lobby->set_delta_tags(data_dict.get("tags", Dictionary()));
 		emit_signal("lobby_tagged", lobby->get_tags());

--- a/lobby/scripted_lobby_client.cpp
+++ b/lobby/scripted_lobby_client.cpp
@@ -114,6 +114,7 @@ void ScriptedLobbyClient::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("lobby_joined", PropertyInfo(Variant::OBJECT, "lobby", PROPERTY_HINT_RESOURCE_TYPE, "LobbyInfo"), PropertyInfo(Variant::ARRAY, "peers", PROPERTY_HINT_ARRAY_TYPE, "LobbyPeer")));
 	ADD_SIGNAL(MethodInfo("lobby_left", PropertyInfo(Variant::BOOL, "kicked")));
 	ADD_SIGNAL(MethodInfo("lobby_sealed", PropertyInfo(Variant::BOOL, "sealed")));
+	ADD_SIGNAL(MethodInfo("lobby_hosted", PropertyInfo(Variant::OBJECT, "host", PROPERTY_HINT_RESOURCE_TYPE, "LobbyPeer")));
 	ADD_SIGNAL(MethodInfo("lobby_tagged", PropertyInfo(Variant::DICTIONARY, "tags")));
 	ADD_SIGNAL(MethodInfo("lobby_passworded", PropertyInfo(Variant::BOOL, "password_protected")));
 	ADD_SIGNAL(MethodInfo("lobby_resized", PropertyInfo(Variant::INT, "max_players")));
@@ -806,6 +807,19 @@ void ScriptedLobbyClient::_receive_data(const Dictionary &p_dict) {
 	} else if (command == "lobby_unsealed") {
 		lobby->set_sealed(false);
 		emit_signal("lobby_sealed", false);
+	} else if (command == "lobby_hosted") {
+		Ref<LobbyPeer> new_host = Ref<LobbyPeer>(memnew(LobbyPeer));
+		String new_host_id = data_dict.get("host_id", String());
+		// find the new host in the peers array
+		for (int i = 0; i < peers.size(); ++i) {
+			Ref<LobbyPeer> peer_info = peers[i];
+			if (peer_info->get_id() == new_host_id) {
+				new_host->set_dict(peer_info->get_dict(), false);
+				break;
+			}
+		}
+		lobby->set_host(new_host_id);
+		emit_signal("lobby_hosted", new_host);
 	} else if (command == "lobby_tags") {
 		lobby->set_delta_tags(data_dict.get("tags", Dictionary()));
 		emit_signal("lobby_tagged", lobby->get_tags());


### PR DESCRIPTION
Add an event that calls when a lobby host changes. This can happen if either the host leaves and the game mode is set to leave_disband: false or if the server sets another host (or empty lobby for hostless lobby)